### PR TITLE
Fix displaying error after leaving trade page

### DIFF
--- a/src/vue/common/TradeTopBar.vue
+++ b/src/vue/common/TradeTopBar.vue
@@ -153,21 +153,21 @@ export default {
     },
   },
   async created () {
-    await this.loadBalances()
-    await this.loadTradablePairs()
+    try {
+      await this.loadBalances()
+      await this.loadTradablePairs()
+    } catch (error) {
+      ErrorHandler.processWithoutFeedback(error)
+    }
   },
   methods: {
     ...mapActions({
       loadBalances: vuexTypes.LOAD_ACCOUNT_BALANCES_DETAILS,
     }),
     async loadTradablePairs () {
-      try {
-        const response = await Sdk.horizon.assetPairs.getAll()
-        this.formatTradablePairs(response.data)
-        this.setDefaultSelectedPair(response.data)
-      } catch (error) {
-        ErrorHandler.process(error)
-      }
+      const { data } = await Sdk.horizon.assetPairs.getAll()
+      this.formatTradablePairs(data)
+      this.setDefaultSelectedPair(data)
     },
     formatTradablePairs (pairs) {
       this.formattedPairs = pairs.map(item => {

--- a/src/vue/pages/TradeExchange.vue
+++ b/src/vue/pages/TradeExchange.vue
@@ -133,7 +133,7 @@ export default {
           limit: this.recordsToShow,
         })
       } catch (error) {
-        ErrorHandler.process(error)
+        ErrorHandler.processWithoutFeedback(error)
       }
       this.isTradeHistoryLoading = false
       return response
@@ -155,7 +155,7 @@ export default {
         })
         this.buyOffersList = response.data
       } catch (error) {
-        ErrorHandler.process(error)
+        ErrorHandler.processWithoutFeedback(error)
       }
       this.isBuyOffersLoading = false
     },
@@ -169,7 +169,7 @@ export default {
         })
         this.sellOffersList = response.data
       } catch (error) {
-        ErrorHandler.process(error)
+        ErrorHandler.processWithoutFeedback(error)
       }
       this.isSellOffersLoading = false
     },


### PR DESCRIPTION
Just hide error messages.

We need to do something with pending requests after destroying the component, should we cancel them (like `abort` in `VueResource` or `CancelToken` in `axios`)?