### PR TITLE
fix accessing global assets according to the documentation vuex

### DIFF
--- a/src/vue/modules/buy-back-form/store/index.js
+++ b/src/vue/modules/buy-back-form/store/index.js
@@ -59,7 +59,7 @@ export const actions = {
 
 export const getters = {
   [types.balances]: state => state.balances.map(b => new Balance(b)),
-  [types.assets]: (state, rootGetters) => state.assets
+  [types.assets]: (state, getters, rootState, rootGetters) => state.assets
     .map(a => new AssetRecord(a))
     .filter(a => a.isAllowedToBuyBack && a.owner.id ===
       rootGetters[vuexTypes.accountId]),

--- a/src/vue/modules/dividend-form/store/index.js
+++ b/src/vue/modules/dividend-form/store/index.js
@@ -95,9 +95,11 @@ export const getters = {
   [types.assets]: state => state.assets.filter(
     item => item.balance.id && item.isTransferable && item.isBaseAsset
   ),
-  [types.ownedAssets]: (state, rootGetters) => state.assets.filter(item =>
-    item.owner === rootGetters[vuexTypes.accountId] && item.isShareSubtype
-  ),
+  [types.ownedAssets]: (state, getters, rootState, rootGetters) =>
+    state.assets.filter(
+      item =>
+        item.owner === rootGetters[vuexTypes.accountId] && item.isShareSubtype
+    ),
   [types.balanceHolders]: state => state.balanceHolders
     .map(item => new Balance(item)),
 }


### PR DESCRIPTION
According to vuex [documentation](https://vuex.vuejs.org/guide/modules.html#accessing-global-assets-in-namespaced-modules) rootGetters should be passed as the 4th arguments to getter functions.

### **Actual behavior:**

**rootGetters** are passed as the 2th arguments to getter functions, so it gets *undefined* value and user assets doesn't appear on the form:

![download](https://user-images.githubusercontent.com/54803573/64971536-85ac0e00-d8b0-11e9-9c72-79419c7498c5.png)

### **Expected behavior:**

**rootGetters** are passed as the 4th arguments to getter functions, so user assets  appears on the form:

![download (1)](https://user-images.githubusercontent.com/54803573/64971564-8e044900-d8b0-11e9-8ace-df49cfebe0a3.png)

